### PR TITLE
Jmabrey memory leak

### DIFF
--- a/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageReader.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageReader.java
@@ -556,7 +556,11 @@ public class J2KImageReader extends ImageReader implements MsgLogger {
     //Implemented to fix Memory Leak in JAI Sun Impl
     public void dispose(){
     	if(iis != null){
-    		iis.dispose();
+    		try {
+				iis.close();
+			} catch (IOException e) {
+				// XXX Ignore
+			}
     	}
     	
         imageMetadata = null;

--- a/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageReader.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageReader.java
@@ -552,6 +552,17 @@ public class J2KImageReader extends ImageReader implements MsgLogger {
         }
         return null;
     }
+    
+    //Implemented to fix Memory Leak in JAI Sun Impl
+    public void dispose(){
+    	if(iis != null){
+    		iis.dispose();
+    	}
+    	
+        imageMetadata = null;
+        hd = null;
+        readState = null;
+    }
 
     // --- Begin jj2000.j2k.util.MsgLogger implementation ---
     public void flush() {


### PR DESCRIPTION
An update of jai-imageio/jai-imageio-core#2 from @jmabrey 

.. but this breaks the build in all tests:

```
Tests in error: 
  ConverterTest.testname:32 » IO closed
  Jpeg2000WriteTest.lossless:64 » IO closed
  Jpeg2000WriteTest.lossyWrite:93 » IO closed
```

Details:

```
Running com.github.jaiimageio.jpeg2000.Jpeg2000WriteTest
Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 4.249 sec <<< FAILURE! - in com.github.jaiimageio.jpeg2000.Jpeg2000WriteTest
lossless(com.github.jaiimageio.jpeg2000.Jpeg2000WriteTest)  Time elapsed: 2.72 sec  <<< ERROR!
java.io.IOException: closed
    at javax.imageio.stream.ImageInputStreamImpl.checkClosed(ImageInputStreamImpl.java:110)
    at javax.imageio.stream.ImageInputStreamImpl.close(ImageInputStreamImpl.java:857)
    at javax.imageio.stream.FileImageInputStream.close(FileImageInputStream.java:151)
    at javax.imageio.ImageIO.read(ImageIO.java:1451)
    at javax.imageio.ImageIO.read(ImageIO.java:1308)
    at com.github.jaiimageio.jpeg2000.Jpeg2000WriteTest.lossless(Jpeg2000WriteTest.java:64)

lossyWrite(com.github.jaiimageio.jpeg2000.Jpeg2000WriteTest)  Time elapsed: 1.528 sec  <<< ERROR!
java.io.IOException: closed
    at javax.imageio.stream.ImageInputStreamImpl.checkClosed(ImageInputStreamImpl.java:110)
    at javax.imageio.stream.ImageInputStreamImpl.close(ImageInputStreamImpl.java:857)
    at javax.imageio.stream.FileImageInputStream.close(FileImageInputStream.java:151)
    at javax.imageio.ImageIO.read(ImageIO.java:1451)
    at javax.imageio.ImageIO.read(ImageIO.java:1308)
    at com.github.jaiimageio.jpeg2000.Jpeg2000WriteTest.lossyWrite(Jpeg2000WriteTest.java:93)

Running com.github.jaiimageio.jpeg2000.ConverterTest
[, image/png, image/vnd.wap.wbmp, image/jpeg, image/x-portable-graymap, image/bmp, image/pcx, image/gif, image/x-windows-bmp, image/x-windows-pcx, image/x-pc-paintbrush, image/jpeg2000, image/x-bmp, image/x-pcx, image/jp2, image/x-png, image/x-portable-bitmap, image/x-portable-pixmap, image/tiff, image/x-portable-anymap]
[JPEG 2000, JPG, tiff, bmp, PCX, gif, WBMP, PNG, RAW, JPEG, PNM, tif, TIFF, wbmp, jpeg, jpg, JPEG2000, BMP, pcx, GIF, png, raw, pnm, TIF, jpeg2000, jpeg 2000]
[JPG, JPEG 2000, tiff, bmp, PCX, gif, WBMP, PNG, RAW, JPEG, PNM, tif, TIFF, wbmp, jpeg, jpg, JPEG2000, BMP, pcx, GIF, png, raw, pnm, TIF, jpeg2000, jpeg 2000]
/tmp/imageio-test8840333562322252026.JPEG 2000
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.266 sec <<< FAILURE! - in com.github.jaiimageio.jpeg2000.ConverterTest
testname(com.github.jaiimageio.jpeg2000.ConverterTest)  Time elapsed: 0.266 sec  <<< ERROR!
java.io.IOException: closed
    at javax.imageio.stream.ImageInputStreamImpl.checkClosed(ImageInputStreamImpl.java:110)
    at javax.imageio.stream.ImageInputStreamImpl.close(ImageInputStreamImpl.java:857)
    at javax.imageio.stream.FileImageInputStream.close(FileImageInputStream.java:151)
    at javax.imageio.ImageIO.read(ImageIO.java:1451)
    at javax.imageio.ImageIO.read(ImageIO.java:1308)
    at com.github.jaiimageio.jpeg2000.ConverterTest.testname(ConverterTest.java:32)
```
