### PR TITLE
fixes null pointer exception when using as SPI service

### DIFF
--- a/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KReadState.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KReadState.java
@@ -379,7 +379,7 @@ public class J2KReadState {
 
         if (image == null) {
             raster = Raster.createWritableRaster(
-                sampleModel.createCompatibleSampleModel(destinationRegion.x +
+                getSampleModel().createCompatibleSampleModel(destinationRegion.x +
                                                         destinationRegion.width,
                                                         destinationRegion.y +
                                                         destinationRegion.height),


### PR DESCRIPTION
As the title says - using the SPI Reader causes a null pointer exception in some conditions - this fixes it