### PR TITLE
Check for valid ColorModel

### DIFF
--- a/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KReadState.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KReadState.java
@@ -360,11 +360,16 @@ public class J2KReadState {
                                                         destinationRegion.y +
                                                         destinationRegion.height),
                 new Point(0, 0));
-            image = new BufferedImage(colorModel, raster,
-                                      colorModel.isAlphaPremultiplied(),
-                                      new Hashtable());
-        } else
+            if (colorModel != null) {
+                image = new BufferedImage(colorModel, raster,
+                                          colorModel.isAlphaPremultiplied(),
+                                          new Hashtable());
+            }
+        }
+
+        if (image != null) {
             raster = image.getWritableTile(0, 0);
+        }
 
         destImage = image;
         readSubsampledRaster(raster);


### PR DESCRIPTION
This change fixes a NullPointerException that occuring on codestream data that didn't have file format information.