### PR TITLE
ForwCompTransfSpec: Allow 'false' as an alternative to 'off'

### DIFF
--- a/src/main/java/jj2000/j2k/image/forwcomptransf/ForwCompTransfSpec.java
+++ b/src/main/java/jj2000/j2k/image/forwcomptransf/ForwCompTransfSpec.java
@@ -156,8 +156,12 @@ public class ForwCompTransfSpec extends CompTransfSpec implements FilterTypes {
             return;
         }
 
-        if (param.equalsIgnoreCase("true"))
+        if (param.equalsIgnoreCase("true")) {
             param = "on";
+        }
+        else if (param.equalsIgnoreCase("false")) {
+            param = "off";
+        }
         // Parse argument
         StringTokenizer stk = new StringTokenizer(param);
         String word; // current word


### PR DESCRIPTION
`true` is already supported as an alternative to `on`; extend this logic to permit `false` as well for completeness.

From https://github.com/rleigh-codelibre/jai-tidy/commit/dec52ce9b8b59999fd95df4f4a8fed1c9bb98c95 originating with https://github.com/openmicroscopy/bioformats/commit/1008e0a199136c8b23034d93f5e58061d87c6826

/cc @melissalinkert @sbesson @jburel 