### PR TITLE
Fix NPEs when attempting to read JPEG2000 file as a Raster

### DIFF
--- a/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageReader.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageReader.java
@@ -488,6 +488,10 @@ public class J2KImageReader extends ImageReader implements MsgLogger {
                              ImageReadParam param) throws IOException {
         checkIndex(imageIndex);
         processImageStarted(imageIndex);
+
+        if (param == null) {
+            param = getDefaultReadParam();
+        }
         param = new J2KImageReadParamJava(param);
 
         if (!ignoreMetadata) {

--- a/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KReadState.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KReadState.java
@@ -378,6 +378,7 @@ public class J2KReadState {
         WritableRaster raster = null;
 
         if (image == null) {
+            sampleModel = getSampleModel();
             raster = Raster.createWritableRaster(
                 sampleModel.createCompatibleSampleModel(destinationRegion.x +
                                                         destinationRegion.width,


### PR DESCRIPTION
From https://github.com/rleigh-codelibre/jai-tidy/commit/5a64bacb4070681817eb44edbbbb5811f0e52ed8 originating with https://github.com/openmicroscopy/bioformats/commit/4289a5ab60dc3f30b6b2c8dcb69154e3e3f74fed

/cc @melissalinkert @sbesson @jburel 