### PR TITLE
Fix javadoc warnings

### DIFF
--- a/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageWriter.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageWriter.java
@@ -98,7 +98,7 @@ import com.github.jaiimageio.jpeg2000.J2KImageWriteParam;
  * The encoding process may re-tile image, clip, subsample, and select bands
  * using the parameters specified in the <code>ImageWriteParam</code>.
  *
- * @see com.sun.media.imageio.plugins.J2KImageWriteParam
+ * @see com.github.jaiimageio.jpeg2000.J2KImageWriteParam
  */
 public class J2KImageWriter extends ImageWriter {
     /** Wrapper for the protected method <code>processImageProgress</code>

--- a/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KReadState.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KReadState.java
@@ -157,7 +157,7 @@ public class J2KReadState {
      *                  from the input stream.
      *  @param reader The <code>J2KImageReader</code> which holds this state.
      *                It is necessary for processing abortion.
-     *  @throw IllegalArgumentException If the provided <code>iis</code>,
+     *  @throws IllegalArgumentException If the provided <code>iis</code>,
      *          <code>param</code> or <code>metadata</code> is <code>null</code>.
      */
     public J2KReadState(ImageInputStream iis,
@@ -180,7 +180,7 @@ public class J2KReadState {
      *  @param param The reading parameters.
      *  @param reader The <code>J2KImageReader</code> which holds this state.
      *                It is necessary for processing abortion.
-     *  @throw IllegalArgumentException If the provided <code>iis</code>,
+     *  @throws IllegalArgumentException If the provided <code>iis</code>,
      *          or <code>param</code> is <code>null</code>.
      */
     public J2KReadState(ImageInputStream iis,

--- a/src/main/java/com/github/jaiimageio/jpeg2000/impl/RenderedImageSrc.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/impl/RenderedImageSrc.java
@@ -145,7 +145,7 @@ public class RenderedImageSrc implements BlkImgDataSrc {
      * @param param The <code>J2KImageWriteParamJava</code> used in encoding.
      * @param writer The <code>J2KImageWriter</code> performs the encoding.
      *
-     * @param IOException If an error occurs while opening the file.
+     * @throws IOException If an error occurs while opening the file.
      */
     public RenderedImageSrc(Raster raster,
                             J2KImageWriteParamJava param,
@@ -180,7 +180,7 @@ public class RenderedImageSrc implements BlkImgDataSrc {
      * @param param The <code>J2KImageWriteParamJava</code> used in encoding.
      * @param writer The <code>J2KImageWriter</code> performs the encoding.
      *
-     * @param IOException If an error occurs while opening the file.
+     * @throws IOException If an error occurs while opening the file.
      * */
     public RenderedImageSrc(RenderedImage src,
                             J2KImageWriteParamJava param,
@@ -431,7 +431,7 @@ public class RenderedImageSrc implements BlkImgDataSrc {
      * subsampling (i.e., all components, or components, have the same
      * dimensions in pixels).
      *
-     * @param c The index of the component, from 0 to C-1.
+     * @param n The index of the component, from 0 to C-1.
      *
      * @return The width in pixels of component <tt>n</tt> in the current
      * tile.
@@ -546,7 +546,7 @@ public class RenderedImageSrc implements BlkImgDataSrc {
      * coordinates). These are the coordinates of the current tile's (not
      * active tile) upper-left corner relative to the canvas.
      *
-     * @param co If not null the object is used to return the values, if null
+     * @param p If not null the object is used to return the values, if null
      * a new one is created and returned.
      *
      * @param c The index of the component (between 0 and C-1)

--- a/src/main/java/jj2000/j2k/IntegerSpec.java
+++ b/src/main/java/jj2000/j2k/IntegerSpec.java
@@ -91,7 +91,7 @@ public class IntegerSpec extends ModuleSpec{
      *
      * @param type The allowed specifications type
      *
-     * @param optName The name of the option to process
+     * @param defaultValue The name of the option to process
      *
      * */
     public IntegerSpec(int nt, int nc, byte type, J2KImageWriteParamJava wp, String values,

--- a/src/main/java/jj2000/j2k/ModuleSpec.java
+++ b/src/main/java/jj2000/j2k/ModuleSpec.java
@@ -197,7 +197,7 @@ public class ModuleSpec implements Cloneable {
      * Rotate the ModuleSpec instance by 90 degrees (this modifies only tile
      * and tile-component specifications).
      *
-     * @param nT Number of tiles along horizontal and vertical axis after
+     * @param anT Number of tiles along horizontal and vertical axis after
      * rotation. 
      * */
     public void rotate90(Point anT) {
@@ -317,7 +317,7 @@ public class ModuleSpec implements Cloneable {
      * Sets default value for specified tile and specValType tag if
      * allowed by its priority.
      *
-     * @param c Tile index.
+     * @param t Tile index.
      * */
     public void setTileDef(int t, Object value){
         if ( specType == SPEC_TYPE_COMP ) {

--- a/src/main/java/jj2000/j2k/StringSpec.java
+++ b/src/main/java/jj2000/j2k/StringSpec.java
@@ -89,7 +89,7 @@ public class StringSpec extends ModuleSpec{
      * @param type the type of the specification module i.e. tile specific,
      * component specific or both.
      *
-     * @param name of the option using boolean spec.
+     * @param defaultValue name of the option using boolean spec.
      *
      * @param list The list of all recognized argument in a String array
      *

--- a/src/main/java/jj2000/j2k/codestream/CoordInfo.java
+++ b/src/main/java/jj2000/j2k/codestream/CoordInfo.java
@@ -77,7 +77,6 @@ public abstract class CoordInfo {
      *
      * @param h The height
      *
-     * @param idx The object's index
      * */
     public CoordInfo(int ulx, int uly, int w, int h) {
         this.ulx = ulx;

--- a/src/main/java/jj2000/j2k/codestream/HeaderInfo.java
+++ b/src/main/java/jj2000/j2k/codestream/HeaderInfo.java
@@ -84,8 +84,6 @@ public class HeaderInfo implements Markers,ProgressionType,FilterTypes,
         /** 
          * Width of the specified tile-component
          *
-         * @param t Tile index
-         *
          * @param c Component index
          * */
         public int getCompImgWidth(int c) {
@@ -745,7 +743,7 @@ public class HeaderInfo implements Markers,ProgressionType,FilterTypes,
      *
      * @param t index of the tile
      *
-     * @param tp Number of tile-parts
+     * @param ntp Number of tile-parts
      * */
     public String toStringTileHeader(int t, int ntp) {
         int nc = siz.csiz;
@@ -794,7 +792,7 @@ public class HeaderInfo implements Markers,ProgressionType,FilterTypes,
      *
      * @param t index of the tile
      *
-     * @param tp Number of tile-parts
+     * @param ntp Number of tile-parts
      * */
     public String toStringThNoSOT(int t, int ntp) {
         int nc = siz.csiz;

--- a/src/main/java/jj2000/j2k/codestream/reader/HeaderDecoder.java
+++ b/src/main/java/jj2000/j2k/codestream/reader/HeaderDecoder.java
@@ -116,7 +116,6 @@ import com.github.jaiimageio.jpeg2000.impl.J2KImageReadParamJava;
  * displayed and its length parameter is used to skip it.
  *
  * @see DecoderSpecs
- * @see Decoder
  * @see FileBitstreamReaderAgent
  * */
 public class HeaderDecoder implements ProgressionType, Markers,
@@ -2248,7 +2247,7 @@ public class HeaderDecoder implements ProgressionType, Markers,
     /**
      * Return the DecoderSpecs instance filled when reading the headers
      *
-     * @retrieves and reads all marker segments previously found in the
+     * Retrieves and reads all marker segments previously found in the
      * tile-part header.
      *
      * @param tileIdx The index of the current tile
@@ -2496,8 +2495,7 @@ public class HeaderDecoder implements ProgressionType, Markers,
      * @param src The bit stream reader agent where to get code-block data
      * from.
      *
-     * @param pl The parameter list containing parameters applicable to the
-     * entropy decoder (other parameters can also be present).
+     * @param j2krparam The parameters applicable to the entropy decoder.
      *
      * @return The ROI descaler
      * */

--- a/src/main/java/jj2000/j2k/codestream/writer/FileCodestreamWriter.java
+++ b/src/main/java/jj2000/j2k/codestream/writer/FileCodestreamWriter.java
@@ -137,8 +137,6 @@ public class FileCodestreamWriter extends CodestreamWriter
      * @param mb The maximum number of bytes that can be written to the bit
      * stream.
      *
-     * @param encSpec The encoder's specifications
-     *
      * @exception IOException If an error occurs while trying to open the file
      * for writing or while writing the magic number.
      * */

--- a/src/main/java/jj2000/j2k/codestream/writer/HeaderEncoder.java
+++ b/src/main/java/jj2000/j2k/codestream/writer/HeaderEncoder.java
@@ -87,7 +87,6 @@ import com.github.jaiimageio.jpeg2000.impl.J2KImageWriteParamJava;
  * whereas tile-part headers are written when the EBCOTRateAllocator instance
  * calls encodeTilePartHeader.
  *
- * @see Encoder
  * @see Markers
  * @see EBCOTRateAllocator
  * */
@@ -161,7 +160,7 @@ public class HeaderEncoder implements Markers, StdEntropyCoderOptions {
      *
      * @param tiler The tiler module.
      *
-     * @param encSpec The encoder specifications
+     * @param wp The encoder specifications
      *
      * @param roiSc The ROI scaler module.
      *
@@ -1693,7 +1692,7 @@ public class HeaderEncoder implements Markers, StdEntropyCoderOptions {
      * (if needed)</li> <li>RGN (if needed)</li> <li>POC (if needed)</li>
      * <li>SOD</li> </ol>
      *
-     * @param length The length of the current tile-part.
+     * @param tileLength The length of the current tile-part.
      *
      * @param tileIdx Index of the tile to write
      * */

--- a/src/main/java/jj2000/j2k/codestream/writer/PktEncoder.java
+++ b/src/main/java/jj2000/j2k/codestream/writer/PktEncoder.java
@@ -245,12 +245,11 @@ public class PktEncoder {
      * @param infoSrc The source of information to construct the
      * object.
      *
-     * @param encSpec The parameters for the encoding
+     * @param wp The parameters for the encoding
      *
-     * @param maxNumPrec Maximum number of precinct in each tile, component
+     * @param numPrec Maximum number of precinct in each tile, component
      * and resolution level.
      *
-     * @param pl ParameterList instance that holds command line options
      * */
     public PktEncoder(CodedCBlkDataSrcEnc infoSrc, J2KImageWriteParamJava wp,
                       Point[][][] numPrec) {

--- a/src/main/java/jj2000/j2k/entropy/CBlkSizeSpec.java
+++ b/src/main/java/jj2000/j2k/entropy/CBlkSizeSpec.java
@@ -85,7 +85,7 @@ public class CBlkSizeSpec extends ModuleSpec {
 
     /**
      * Creates a new CBlkSizeSpec object for the specified number of tiles and
-     * components and the ParameterList instance.
+     * components and the parameters instance.
      *
      * @param nt The number of tiles
      *
@@ -94,9 +94,7 @@ public class CBlkSizeSpec extends ModuleSpec {
      * @param type the type of the specification module i.e. tile specific,
      * component specific or both.
      *
-     * @param imgsrc The image source (used to get the image size)
-     *
-     * @param pl The ParameterList instance
+     * @param wp The parameters
      * */
     public CBlkSizeSpec(int nt, int nc, byte type, J2KImageWriteParamJava wp, String values) {
         super(nt, nc, type);
@@ -414,7 +412,7 @@ public class CBlkSizeSpec extends ModuleSpec {
      * Sets default value for specified tile and specValType tag if allowed by
      * its priority.
      *
-     * @param c Tile index.
+     * @param t Tile index.
      *
      * @param value Tile's default value
      *  */

--- a/src/main/java/jj2000/j2k/entropy/decoder/MQDecoder.java
+++ b/src/main/java/jj2000/j2k/entropy/decoder/MQDecoder.java
@@ -676,10 +676,6 @@ public class MQDecoder {
      * original probability distribution depends on the actual
      * implementation of the arithmetic coder or decoder.
      *
-     * @param c The index of the context (it starts at 0).
-     *
-     *
-     *
      */
     public final void resetCtxts(){
         System.arraycopy(initStates,0,I,0,I.length);

--- a/src/main/java/jj2000/j2k/entropy/decoder/StdEntropyDecoder.java
+++ b/src/main/java/jj2000/j2k/entropy/decoder/StdEntropyDecoder.java
@@ -599,9 +599,7 @@ public class StdEntropyDecoder extends EntropyDecoder
      *
      * @param src The source of data
      *
-     * @param opt The options to use for this encoder. It is a mix of the
-     * 'OPT_TERM_PASS', 'OPT_RESET_MQ', 'OPT_VERT_STR_CAUSAL', 'OPT_BYPASS' and
-     * 'OPT_SEG_SYMBOLS' option flags.
+     * @param decSpec The decoder specifications
      *
      * @param doer If true error detection will be performed, if any error
      * detection features have been enabled.

--- a/src/main/java/jj2000/j2k/entropy/encoder/EntropyCoder.java
+++ b/src/main/java/jj2000/j2k/entropy/encoder/EntropyCoder.java
@@ -286,7 +286,7 @@ public abstract class EntropyCoder extends ImgDataAdapter
      *
      * @param wp The parameter list (or options).
      *
-     * @param cbks Code-block size specifications
+     * @param cblks Code-block size specifications
      *
      * @param pss Precinct partition specifications
      *

--- a/src/main/java/jj2000/j2k/entropy/encoder/PostCompRateAllocator.java
+++ b/src/main/java/jj2000/j2k/entropy/encoder/PostCompRateAllocator.java
@@ -145,11 +145,11 @@ public abstract class PostCompRateAllocator extends ImgDataAdapter {
      *
      * @param src The source of entropy coded data.
      *
-     * @param ln The number of layers to create
-     *
-     * @param pt The Progression type, as defined in 'ProgressionType'.
+     * @param nl The number of layers to create
      *
      * @param bw The packet bit stream writer.
+     *
+     * @param wp The parameters list
      *
      * @see ProgressionType
      * */
@@ -177,8 +177,6 @@ public abstract class PostCompRateAllocator extends ImgDataAdapter {
      * simulated but before calling the runAndWrite() one. The header must be
      * rewritten after a call to this method since the number of layers may
      * change.
-     *
-     * @param oldSyntax Whether or not the old syntax is used.
      *
      * @see #runAndWrite
      * */
@@ -226,12 +224,14 @@ public abstract class PostCompRateAllocator extends ImgDataAdapter {
      *
      * @param src The source of entropy coded data.
      *
-     * @param pl The parameter lis (or options).
-     *
+
      * @param rate The target bitrate for the rate allocation
      *
      * @param bw The bit stream writer object, where the bit stream data will
      * be written.
+     *
+     * @param wp The parameter list (or options).
+     *
      * */
     public static PostCompRateAllocator createInstance(CodedCBlkDataSrcEnc src,
                                                        float rate,

--- a/src/main/java/jj2000/j2k/entropy/encoder/StdEntropyCoder.java
+++ b/src/main/java/jj2000/j2k/entropy/encoder/StdEntropyCoder.java
@@ -894,7 +894,7 @@ public class StdEntropyCoder extends EntropyCoder
      *
      * @param src The source of data
      *
-     * @param cbks Code-block size specifications
+     * @param cblks Code-block size specifications
      *
      * @param pss Precinct partition specifications
      *

--- a/src/main/java/jj2000/j2k/fileformat/reader/FileFormatReader.java
+++ b/src/main/java/jj2000/j2k/fileformat/reader/FileFormatReader.java
@@ -146,8 +146,6 @@ public class FileFormatReader implements FileFormatBoxes{
      * and if so finds the first codestream in the file. Currently, the
      * information in the codestream is not used
      *
-     * @param in The RandomAccessIO from which to read the file format
-     *
      * @exception java.io.IOException If an I/O error ocurred.
      *
      * @exception java.io.EOFException If end of file is reached
@@ -348,12 +346,7 @@ public class FileFormatReader implements FileFormatBoxes{
     /**
      * This method reads the JP2Header box
      *
-     * @param pos The position in the file
-     *
      * @param length The length of the JP2Header box
-     *
-     * @param long length The length of the JP2Header box if greater than
-     * 1<<32
      *
      * @return false if the JP2Header box was not found or invalid else true
      *
@@ -411,11 +404,9 @@ public class FileFormatReader implements FileFormatBoxes{
      * This method skips the Contiguous codestream box and adds position
      * of contiguous codestream to a vector
      *
-     * @param pos The position in the file
-     *
      * @param length The length of the JP2Header box
      *
-     * @param long length The length of the JP2Header box if greater than 1<<32
+     * @param longLength The length of the JP2Header box if greater than 1<<32
      *
      * @return false if the Contiguous codestream box was not found or invalid
      * else true

--- a/src/main/java/jj2000/j2k/fileformat/writer/FileFormatWriter.java
+++ b/src/main/java/jj2000/j2k/fileformat/writer/FileFormatWriter.java
@@ -130,7 +130,7 @@ public class FileFormatWriter implements FileFormatBoxes {
      * The constructor of the FileFormatWriter. It receives all the
      * information necessary about a codestream to generate a legal JP2 file
      *
-     * @param filename The name of the file that is to be made a JP2 file
+     * @param file The name of the file that is to be made a JP2 file
      *
      * @param height The height of the image
      *
@@ -253,8 +253,6 @@ public class FileFormatWriter implements FileFormatBoxes {
 
     /**
      * This method writes the Contiguous codestream box
-     *
-     * @param cs The contiguous codestream
      *
      * @exception java.io.IOException If an I/O error ocurred.
      * */

--- a/src/main/java/jj2000/j2k/image/DataBlkFloat.java
+++ b/src/main/java/jj2000/j2k/image/DataBlkFloat.java
@@ -102,7 +102,7 @@ public class DataBlkFloat extends DataBlk {
      * Creates a DataBlkFloat which is the copy of the DataBlkFloat
      * given as paramter.
      *
-     * @param DataBlkFloat the object to be copied.
+     * @param src the object to be copied.
      *
      *
      * */

--- a/src/main/java/jj2000/j2k/image/DataBlkInt.java
+++ b/src/main/java/jj2000/j2k/image/DataBlkInt.java
@@ -102,7 +102,7 @@ public class DataBlkInt extends DataBlk {
      * Creates a DataBlkInt which is the copy of the DataBlkInt
      * given as paramter.
      *
-     * @param DataBlkInt the object to be copied.
+     * @param src the object to be copied.
      *
      *
      * */

--- a/src/main/java/jj2000/j2k/image/forwcomptransf/ForwCompTransf.java
+++ b/src/main/java/jj2000/j2k/image/forwcomptransf/ForwCompTransf.java
@@ -115,7 +115,7 @@ public class ForwCompTransf extends ImgDataAdapter
      * @param imgSrc The source from where to get the data to be
      * transformed
      *
-     * @param encSpec The encoder specifications
+     * @param wp The encoder specifications
      *
      * @see BlkImgDataSrc
      * */

--- a/src/main/java/jj2000/j2k/quantization/dequantizer/Dequantizer.java
+++ b/src/main/java/jj2000/j2k/quantization/dequantizer/Dequantizer.java
@@ -106,7 +106,7 @@ public abstract class Dequantizer extends MultiResImgDataAdapter
      *
      * @param src From where to obtain the quantized data.
      *
-     * @param rb The number of "range bits" for each component (must be the
+     * @param utrb The number of "range bits" for each component (must be the
      * "range bits" of the un-transformed components. For a definition of
      * "range bits" see the getNomRangeBits() method.
      *

--- a/src/main/java/jj2000/j2k/quantization/dequantizer/StdDequantizer.java
+++ b/src/main/java/jj2000/j2k/quantization/dequantizer/StdDequantizer.java
@@ -110,13 +110,11 @@ public class StdDequantizer extends Dequantizer {
      *
      * @param src From where to obtain the quantized data.
      *
-     * @param rb The number of "range bits" (bitdepth) for each component
+     * @param utrb The number of "range bits" (bitdepth) for each component
      * (must be the "range bits" of the un-transformed components). For a
      * definition of "range bits" see the getNomRangeBits() method.
      *
-     * @param qts The quantizer type spec
-     *
-     * @param qsss The dequantizer step sizes spec
+     * @param decSpec The decoder specifications
      *
      * @see Dequantizer#getNomRangeBits
      *

--- a/src/main/java/jj2000/j2k/quantization/quantizer/Quantizer.java
+++ b/src/main/java/jj2000/j2k/quantization/quantizer/Quantizer.java
@@ -252,7 +252,7 @@ public abstract class Quantizer extends ImgDataAdapter
      *
      * @param src The source of data to be quantized
      *
-     * @param encSpec Encoder specifications
+     * @param wp The encoder parameters
      *
      * @exception IllegalArgumentException If an error occurs while parsing
      * the options in 'pl'

--- a/src/main/java/jj2000/j2k/quantization/quantizer/StdQuantizer.java
+++ b/src/main/java/jj2000/j2k/quantization/quantizer/StdQuantizer.java
@@ -138,7 +138,7 @@ public class StdQuantizer extends Quantizer {
      *
      * @param src The source of wavelet transform coefficients.
      *
-     * @param encSpec The encoder specifications
+     * @param wp The encoder parameters
      * */
     public StdQuantizer(CBlkWTDataSrc src,J2KImageWriteParamJava wp){
 	super(src);

--- a/src/main/java/jj2000/j2k/roi/ROIDeScaler.java
+++ b/src/main/java/jj2000/j2k/roi/ROIDeScaler.java
@@ -303,7 +303,7 @@ public class ROIDeScaler extends MultiResImgDataAdapter
      *
      * @param src The source of data that is to be descaled
      *
-     * @param pl The parameter list (or options).
+     * @param j2krparam The parameter list (or options).
      *
      * @param decSpec The decoding specifications
      *

--- a/src/main/java/jj2000/j2k/roi/encoder/ROI.java
+++ b/src/main/java/jj2000/j2k/roi/encoder/ROI.java
@@ -106,9 +106,9 @@ public class ROI{
      *
      * @param comp The component the ROI belongs to
      *
-     * @param x x-coordinate of upper left corner of ROI
+     * @param ulx x-coordinate of upper left corner of ROI
      *
-     * @param y y-coordinate of upper left corner of ROI
+     * @param uly y-coordinate of upper left corner of ROI
      *
      * @param w width of ROI
      *
@@ -133,7 +133,7 @@ public class ROI{
      *
      * @param y y-coordinate of center of ROI
      *
-     * @param w radius of ROI
+     * @param rad radius of ROI
      */
     public ROI(int comp, int x, int y, int rad){
         arbShape = false;

--- a/src/main/java/jj2000/j2k/roi/encoder/ROIScaler.java
+++ b/src/main/java/jj2000/j2k/roi/encoder/ROIScaler.java
@@ -156,7 +156,7 @@ public class ROIScaler extends ImgDataAdapter implements CBlkQuantDataSrcEnc {
      *
      * @param uba Flag indicating whether block aligning is used.
      *
-     * @param encSpec The encoder specifications for addition of roi specs
+     * @param wp The encoder parameters for addition of roi specs
      * */
     public ROIScaler(Quantizer src,
                      ROIMaskGenerator mg,
@@ -235,9 +235,7 @@ public class ROIScaler extends ImgDataAdapter implements CBlkQuantDataSrcEnc {
      *
      * @param src The source of data to scale
      *
-     * @param pl The parameter list (or options).
-     *
-     * @param encSpec The encoder specifications for addition of roi specs
+     * @param wp The encoder parameters for addition of roi specs
      *
      * @exception IllegalArgumentException If an error occurs while parsing
      * the options in 'pl'
@@ -714,7 +712,7 @@ public class ROIScaler extends ImgDataAdapter implements CBlkQuantDataSrcEnc {
      * tile-component, and stores it in the 'maxMagBits' array. This is called
      * by the constructor
      *
-     * @param encSpec The encoder specifications for addition of roi specs
+     * @param wp The encoder parameters for addition of roi specs
      * */
     private void calcMaxMagBits(J2KImageWriteParamJava wp) {
         int tmp;

--- a/src/main/java/jj2000/j2k/roi/encoder/RectROIMaskGenerator.java
+++ b/src/main/java/jj2000/j2k/roi/encoder/RectROIMaskGenerator.java
@@ -94,8 +94,6 @@ public class RectROIMaskGenerator extends ROIMaskGenerator{
      *
      * @param ROIs The ROI info.
      *
-     * @param maxShift The flag indicating use of Maxshift method.
-     *
      * @param nrc number of components.
      * */
     public RectROIMaskGenerator(ROI[] ROIs, int nrc){

--- a/src/main/java/jj2000/j2k/roi/encoder/SubbandRectROIMask.java
+++ b/src/main/java/jj2000/j2k/roi/encoder/SubbandRectROIMask.java
@@ -82,8 +82,6 @@ public class SubbandRectROIMask extends SubbandROIMask{
      *
      * @param lrys The lower right y coordinates of the ROIs
      *
-     * @param lrys The lower right y coordinates of the ROIs
-     *
      * @param nr Number of ROIs that affect this tile
      * */
     public SubbandRectROIMask(Subband sb, int[] ulxs, int[] ulys, int[] lrxs,

--- a/src/main/java/jj2000/j2k/util/CodestreamManipulator.java
+++ b/src/main/java/jj2000/j2k/util/CodestreamManipulator.java
@@ -119,7 +119,7 @@ public class CodestreamManipulator{
     /**
      * Instantiates a codestream manipulator..
      *
-     * @param outname The name of the original outfile
+     * @param file The name of the original outfile
      *
      * @param nt The number of tiles in the image
      *

--- a/src/main/java/jj2000/j2k/util/ISRandomAccessIO.java
+++ b/src/main/java/jj2000/j2k/util/ISRandomAccessIO.java
@@ -323,7 +323,7 @@ public class ISRandomAccessIO implements RandomAccessIO {
      *
      * @param off The index in 'b' where to place the first byte read.
      *
-     * @param len The number of bytes to read.
+     * @param n The number of bytes to read.
      *
      * @exception EOFException If the end-of file was reached before
      * getting all the necessary data.

--- a/src/main/java/jj2000/j2k/wavelet/WTDecompSpec.java
+++ b/src/main/java/jj2000/j2k/wavelet/WTDecompSpec.java
@@ -125,8 +125,6 @@ public class WTDecompSpec {
      *
      * @param nc The number of components
      *
-     * @param nt The number of tiles
-     *
      * @param dec The main default decomposition type
      *
      * @param lev The main default number of decomposition levels
@@ -184,8 +182,6 @@ public class WTDecompSpec {
      *
      * @param n The component index
      *
-     * @param t The tile index, in raster scan order.
-     *
      * @return The specification type for component 'n' and tile 't'.
      *
      *
@@ -224,8 +220,6 @@ public class WTDecompSpec {
      *
      * @param n The component index.
      *
-     * @param t The tile index, in raster scan order
-     *
      * @return The decomposition type to be used.
      *
      *
@@ -252,8 +246,6 @@ public class WTDecompSpec {
      * <P>NOTE: The tile specific things are not supported yet
      *
      * @param n The component index.
-     *
-     * @param t The tile index, in raster scan order
      *
      * @return The decomposition number of levels.
      *

--- a/src/main/java/jj2000/j2k/wavelet/WTFilterSpec.java
+++ b/src/main/java/jj2000/j2k/wavelet/WTFilterSpec.java
@@ -96,8 +96,6 @@ public abstract class WTFilterSpec {
      *
      * @param nc The number of components
      *
-     * @param nt The number of tiles
-     *
      *
      * */
     protected WTFilterSpec(int nc) {
@@ -125,8 +123,6 @@ public abstract class WTFilterSpec {
      * <P>NOTE: The tile specific things are not supported yet
      *
      * @param n The component index
-     *
-     * @param t The tile index, in raster scan order.
      *
      * @return The specification type for component 'n' and tile 't'.
      *

--- a/src/main/java/jj2000/j2k/wavelet/analysis/AnWTFilter.java
+++ b/src/main/java/jj2000/j2k/wavelet/analysis/AnWTFilter.java
@@ -174,14 +174,6 @@ public abstract class AnWTFilter implements WaveletFilter{
      * @param inStep This is the step, or interleave factor, of the
      * input signal samples in the inSig array. See above.
      *
-     * @param tailOvrlp This is the number of samples in the input
-     * signal before the first sample to filter that can be used for
-     * overlap. See above.
-     *
-     * @param headOvrlp This is the number of samples in the input
-     * signal after the last sample to filter that can be used for
-     * overlap. See above.
-     *
      * @param lowSig This is the array where the low-pass output
      * signal is placed. It must be of the same type as inSig and it
      * should be long enough to contain the output signal.

--- a/src/main/java/jj2000/j2k/wavelet/analysis/AnWTFilterFloatLift9x7.java
+++ b/src/main/java/jj2000/j2k/wavelet/analysis/AnWTFilterFloatLift9x7.java
@@ -660,7 +660,7 @@ public class AnWTFilterFloatLift9x7 extends AnWTFilterFloat {
      * <P>Currently the implementation of this method only tests if 'obj' is
      * also of the class AnWTFilterFloatLift9x7
      *
-     * @param The object against which to test inequality.
+     * @param obj The object against which to test inequality.
      * */
     public boolean equals(Object obj) {
         // To spped up test, first test for reference equality

--- a/src/main/java/jj2000/j2k/wavelet/analysis/AnWTFilterIntLift5x3.java
+++ b/src/main/java/jj2000/j2k/wavelet/analysis/AnWTFilterIntLift5x3.java
@@ -489,7 +489,7 @@ public class AnWTFilterIntLift5x3 extends AnWTFilterInt {
      * <P>Currently the implementation of this method only tests if 'obj' is
      * also of the class AnWTFilterIntLift5x3.
      *
-     * @param The object against which to test inequality.
+     * @param obj The object against which to test inequality.
      * */
     public boolean equals(Object obj) {
         // To speed up test, first test for reference equality

--- a/src/main/java/jj2000/j2k/wavelet/analysis/ForwWTFull.java
+++ b/src/main/java/jj2000/j2k/wavelet/analysis/ForwWTFull.java
@@ -135,7 +135,7 @@ public class ForwWTFull extends ForwardWT {
      *
      * @param src From where the image data should be obtained.
      *
-     * @param encSpec The encoder specifications
+     * @param wp The writing parameters
      *
      * @param pox The horizontal coordinate of the cell and code-block
      * partition origin with respect to the canvas origin, on the reference

--- a/src/main/java/jj2000/j2k/wavelet/analysis/ForwardWT.java
+++ b/src/main/java/jj2000/j2k/wavelet/analysis/ForwardWT.java
@@ -122,9 +122,7 @@ public abstract class ForwardWT extends ImgDataAdapter
      *
      * @param src The source of data to be transformed
      *
-     * @param pl The parameter list (or options).
-     *
-     * @param kers The encoder specifications.
+     * @param wp The writing parameters.
      *
      * @return A new ForwardWT object with the specified filters and options
      * from 'pl'.

--- a/src/main/java/jj2000/j2k/wavelet/synthesis/InvWT.java
+++ b/src/main/java/jj2000/j2k/wavelet/synthesis/InvWT.java
@@ -79,9 +79,6 @@ public interface InvWT extends WaveletTransform {
      *
      * @param rl The image resolution level.
      *
-     * @return The vertical coordinate of the image origin in the canvas
-     * system, on the reference grid.
-     *
      * */
     public void setImgResLevel(int rl);
 }

--- a/src/main/java/jj2000/j2k/wavelet/synthesis/InvWTAdapter.java
+++ b/src/main/java/jj2000/j2k/wavelet/synthesis/InvWTAdapter.java
@@ -117,8 +117,6 @@ public abstract class InvWTAdapter implements InvWT {
      *
      * @param rl The image resolution level.
      *
-     * @return The vertical coordinate of the image origin in the canvas
-     * system, on the reference grid.
      * */
     public void setImgResLevel(int rl) {
         if(rl<0) {

--- a/src/main/java/jj2000/j2k/wavelet/synthesis/InverseWT.java
+++ b/src/main/java/jj2000/j2k/wavelet/synthesis/InverseWT.java
@@ -98,8 +98,7 @@ public abstract class InverseWT extends InvWTAdapter
      * @param src The source of data for the inverse wavelet
      * transform.
      *
-     * @param pl The parameter list containing parameters applicable to the
-     * inverse wavelet transform (other parameters can also be present).
+     * @param decSpec The decoder specifications
      * */
     public static InverseWT createInstance(CBlkWTDataSrcDec src,
                                            DecoderSpecs decSpec) {

--- a/src/main/java/jj2000/j2k/wavelet/synthesis/MultiResImgData.java
+++ b/src/main/java/jj2000/j2k/wavelet/synthesis/MultiResImgData.java
@@ -225,7 +225,7 @@ public interface MultiResImgData {
      * Returns the height in pixels of the specified component in the overall
      * image, for the given resolution level.
      *
-     * @param c The index of the component, from 0 to N-1.
+     * @param n The index of the component, from 0 to N-1.
      *
      * @param rl The resolution level, from 0 to L.
      *


### PR DESCRIPTION
From https://github.com/rleigh-codelibre/jai-tidy/commit/c255dae38f05c9ca491b14e1a593d71bdc1eed8a and https://github.com/rleigh-codelibre/jai-tidy/commit/5fca2c9c725d10dee5c930a35d16125cb3d55cf9

A collection of fairly trivial javadoc warning fixes.

Testing: Check that the method parameters match the javadoc param names.