### PR TITLE
J2KImageReader: Add dispose method to fix an extreme memory leak

### DIFF
--- a/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageReader.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageReader.java
@@ -557,6 +557,20 @@ public class J2KImageReader extends ImageReader implements MsgLogger {
         return null;
     }
 
+    //Implemented to fix Memory Leak in JAI Sun Impl
+    public void dispose(){
+        if(iis != null){
+            try {
+                iis.close();
+            } catch (IOException e) {
+                // XXX Ignore
+            }
+        }
+        imageMetadata = null;
+        hd = null;
+        readState = null;
+    }
+
     // --- Begin jj2000.j2k.util.MsgLogger implementation ---
     public void flush() {
         // Do nothing.

--- a/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageReader.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageReader.java
@@ -558,6 +558,7 @@ public class J2KImageReader extends ImageReader implements MsgLogger {
     }
 
     //Implemented to fix Memory Leak in JAI Sun Impl
+    @Override
     public void dispose(){
         if(iis != null){
             try {


### PR DESCRIPTION
See https://github.com/jai-imageio/jai-imageio-core/pull/2 for original PR.