### PR TITLE
jj2000: StdEntropyCoder: Use the lossless distortion tables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/jj2000/j2k/entropy/encoder/StdEntropyCoder.java
+++ b/src/main/java/jj2000/j2k/entropy/encoder/StdEntropyCoder.java
@@ -1410,8 +1410,8 @@ public class StdEntropyCoder extends EntropyCoder
 
         // Loop on significant magnitude bit-planes doing the 3 passes
         curbp = 30-skipbp;
-        fs = FS_LOSSY;
-        fm = FM_LOSSY;
+        fs = FS_LOSSLESS;
+        fm = FM_LOSSLESS;
         msew = Math.pow(2,((curbp-lmb)<<1)-MSE_LKP_FRAC_BITS)*
             srcblk.sb.stepWMSE*srcblk.wmseScaling;
         totdist = 0f;


### PR DESCRIPTION
From https://github.com/rleigh-codelibre/jai-tidy/commit/43c88850a1e6ffb25fa513be8868b719a1f3b49a

This PR is not necessarily appropriate to merge.  Are there situations where we want to use the lossy tables?  Should this be configurable?  If so, how should it be done?  Could we add it to `StdEntropyCoderOptions`?

/cc @melissalinkert 