### PR TITLE
Java 9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk7
   - oraclejdk8
+  - oraclejdk9
   - openjdk7
-    #  - openjdk8
+  - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
   - oraclejdk7
-  - openjdk6
+  - oraclejdk8
   - openjdk7
+    #  - openjdk8

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-      <jaiimageio.core.version>1.3.2-SNAPSHOT</jaiimageio.core.version>
+      <jaiimageio.core.version>1.4.0</jaiimageio.core.version>
     </properties>
 
     <name>JPEG2000 support for Java Advanced Imaging Image I/O Tools API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
         <executions>
           <execution>
             <goals>
-              <goal>jar</goal>
               <goal>test-jar</goal>
             </goals>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>
@@ -232,7 +232,7 @@
     <profile>
       <id>pre-java8</id>
       <activation>
-        <jdk>[1.5,1.8)</jdk>
+        <jdk>[1.6,1.8)</jdk>
       </activation>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-      <jaiimageio.core.version>1.3.1</jaiimageio.core.version>
+      <jaiimageio.core.version>1.3.2-SNAPSHOT</jaiimageio.core.version>
     </properties>
 
     <name>JPEG2000 support for Java Advanced Imaging Image I/O Tools API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.7.0</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
@@ -93,7 +93,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20</version>
+        <version>2.21.0</version>
         <configuration>
           <skip>false</skip>
           <systemProperties>
@@ -135,13 +135,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.6</version>
+        <version>3.7</version>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
-        <version>3.3.0</version>
+        <version>3.5.0</version>
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
@@ -166,18 +166,28 @@
       <plugin>
 	<groupId>org.codehaus.mojo</groupId>
 	<artifactId>versions-maven-plugin</artifactId>
-	<version>2.4</version>
+	<version>2.5</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <goals>
+               <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <linksource>true</linksource>
+          <protected>true</protected>
+          <links>
+            <link>http://docs.oracle.com/javase/8/docs/api/</link>
+          </links>
+        </configuration>
       </plugin>
     </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.4</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 
   <profiles>
@@ -199,58 +209,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>java8-and-higher</id>
-      <activation>
-        <jdk>[1.8,</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <additionalparam>-Xdoclint:none</additionalparam>
-              <linksource>true</linksource>
-              <protected>true</protected>
-              <links>
-                <link>http://docs.oracle.com/javase/8/docs/api/</link>
-              </links>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>pre-java8</id>
-      <activation>
-        <jdk>[1.6,1.8)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <!-- Override config without doclint option -->
-              <linksource>true</linksource>
-              <protected>true</protected>
-              <links>
-                <link>http://docs.oracle.com/javase/7/docs/api/</link>
-              </links>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
   <prerequisites>
-    <maven>2.2.1</maven>
+    <maven>3.0.5</maven>
   </prerequisites>
   <groupId>com.github.jai-imageio</groupId>  
     <artifactId>jai-imageio-jpeg2000</artifactId>
@@ -43,7 +43,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.6.1</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
@@ -52,7 +52,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.4</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <goals>
@@ -65,7 +65,7 @@
       <plugin> 
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
+        <version>3.0.2</version>
         <executions>
           <execution>
             <goals>
@@ -94,7 +94,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.18.1</version>
+        <version>2.20</version>
         <configuration>
           <skip>false</skip>
           <systemProperties>
@@ -108,7 +108,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.1</version>
+        <version>2.5.3</version>
         <configuration>
           <releaseProfiles>release</releaseProfiles>
         </configuration>
@@ -116,7 +116,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>2.6.1</version>
+        <version>3.0.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -131,18 +131,18 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.7</version>
+        <version>3.0.2</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.4</version>
+        <version>3.6</version>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
-        <version>2.3.7</version>
+        <version>3.3.0</version>
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
@@ -164,13 +164,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+	<groupId>org.codehaus.mojo</groupId>
+	<artifactId>versions-maven-plugin</artifactId>
+	<version>2.4</version>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.1</version>
+          <version>2.10.4</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -272,7 +277,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>2.8</version>
+          <version>2.9</version>
           <reportSets>
             <reportSet>
               <reports>


### PR DESCRIPTION
This PR depends upon https://github.com/jai-imageio/jai-imageio-core/pull/41 and it must be built and installed before testing this PR.  It will also require releasing and the dependency version bumping in order for Travis to go green.

This PR contains the fixes necessary to build and test with Java 9.  With this PR, you can run:

```
MAVEN_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED --add-modules java.activation" mvn install
```

(the `MAVEN_OPTS` is currently needed to run under Java 9, and should hopefully go away once it's updated as well.)
