### PR TITLE
CanWriteProgressive Settings in J2KImageWriteParam

### DIFF
--- a/src/main/java/com/github/jaiimageio/jpeg2000/J2KImageWriteParam.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/J2KImageWriteParam.java
@@ -114,7 +114,7 @@ import javax.imageio.ImageWriteParam;
  *    <td>progressionType</td>
  *    <td> Specifies which type of progression should be used when generating
  *    the codestream.
- *    <p> The format is ont of the progression types defined below:
+ *    <p> The format is one of the progression types defined below:
  *
  *    <p> res : Resolution-Layer-Component-Position
  *    <p> layer: Layer-Resolution-Component-Position
@@ -236,6 +236,7 @@ public class J2KImageWriteParam extends ImageWriteParam {
         canOffsetTiles = true;
         compressionTypes = new String[] {"JPEG2000"};
         canWriteCompressed = true;
+        canWriteProgressive= true;
         tilingMode = MODE_EXPLICIT;
     }
 


### PR DESCRIPTION
I modified J2KImageWriteParam's default settings, adding canWriteProgressive=true to match the ability to set progressive type settings. Not sure why this was different from J2ImageWriteParamJava's default setting. Otherwise when you try to change the default progressive type, the class throws an error. 