### PR TITLE
Bug fix in StdEntropyDecoder.java

### DIFF
--- a/src/main/java/jj2000/j2k/entropy/decoder/StdEntropyDecoder.java
+++ b/src/main/java/jj2000/j2k/entropy/decoder/StdEntropyDecoder.java
@@ -1997,7 +1997,7 @@ public class StdEntropyDecoder extends EntropyDecoder
         sscanw = cblk.w+2;
         jstep = sscanw*STRIPE_HEIGHT/2-cblk.w;
         kstep = dscanw*STRIPE_HEIGHT-cblk.w;
-        setmask = (3<<bp)>>1;
+        setmask = 3<<(bp-1);
         data = (int[]) cblk.getData();
         nstripes = (cblk.h+STRIPE_HEIGHT-1)/STRIPE_HEIGHT;
         causal = (options & OPT_VERT_STR_CAUSAL) != 0;


### PR DESCRIPTION
setmask = (3<<bp)>>1;  works great for unsigned integers however setmask is a signed integer so when bp = 30  the result is negative (-536870912) and thus incorrect. The correct mask result for bit plane 30 should be 1610612736, which is correctly returned by 3<<(bp-1).  This bug results in black 'holes' / 'stripes' in the image as shown here on StackOverflow (https://stackoverflow.com/questions/41977536/black-stain-when-extracting-page-to-image-on-pdfbox-2-0-4)