### PR TITLE
Fix invalid version error for maven dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
   </prerequisites>
   <groupId>com.github.jai-imageio</groupId>  
     <artifactId>jai-imageio-jpeg2000</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-      <jaiimageio.core.version>1.3.1</jaiimageio.core.version>
+      <jaiimageio.core.version>1.4.0</jaiimageio.core.version>
     </properties>
 
     <name>JPEG2000 support for Java Advanced Imaging Image I/O Tools API</name>
@@ -203,7 +203,7 @@
     <profile>
       <id>java8-and-higher</id>
       <activation>
-        <jdk>[1.8,</jdk>
+        <jdk>[1.8,)</jdk>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
Certain versions of maven fail to include this jar as a dependency
because they can't parse the version string `[1.8,`.
Those builds fail with the following error:

```
Unable to resolve artifact: Unable to get dependency information: Unable to read the metadata file for artifact 'com.github.jai-imageio:jai-imageio-jpeg2000:jar': Invalid JDK version in profile 'java8-and-higher': Unbounded range: [1.8, for project com.github.jai-imageio:jai-imageio-jpeg2000
```

To fix this I replaced the version string by `[1.8,)`.

Note that we also needed to update to jai-image-io version 1.4.0 because 1.3.x contains the same issue.

Also see jai-imageio/jai-imageio-core#23