### PR TITLE
Allow up to 3 bytes of padding at the end of stream

### DIFF
--- a/src/main/java/jj2000/j2k/fileformat/reader/FileFormatReader.java
+++ b/src/main/java/jj2000/j2k/fileformat/reader/FileFormatReader.java
@@ -193,16 +193,18 @@ public class FileFormatReader implements FileFormatBoxes{
                 metadata.addNode(new SignatureBox());
 
             // Read all remaining boxes
+            int inputLength = in.length();
             while(!lastBoxFound){
                 pos = in.getPos();
                 length = in.readInt();
-                if((pos+length) == in.length())
+                int remainingLength = inputLength - (pos+length);
+                if(remainingLength >=0 && remainingLength < 4)
                     lastBoxFound = true;
 
                 box = in.readInt();
                 if (length == 0) {
                     lastBoxFound = true;
-                    length = in.length()-in.getPos();
+                    length = inputLength-in.getPos();
                 } else if(length == 1) {
                     longLength = in.readLong();
                     throw new IOException("File too long.");


### PR DESCRIPTION
Fix for use with dcm4che:
DICOM tags have to have even length and there is no way discern actual encoded data length vs padded (at dcm4che level), so padded length can be fed to decompressor as is. Which it currently can't process.

Since anything less than 4 bytes can't comprise a valid box (need to read box type Int), ignoring up to 3 trailing bytes seems safe.

(also there is no need to recalculate RandomAccessIO.length() multiple times)