### PR TITLE
OpenJDK11 fix: Avoid runFinalizersOnExit in DO_TIMING

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,13 +1,15 @@
 # Build modifications
 
-© 2010-2020 University of Manchester <soiland-reyes@cs.manchester.ac.uk>
-© 2014-2015 Stian Soiland-Reyes <stian@soiland-reyes.com>
-© 2015 Yannick De Turck
-© 2017-2018 University of Dundee
-© 2017 Glencoe Software
-© 2017 GNF
-© 2017 connexta / OCTO
-© 2018 Jurgen Doll / Lightware Software
+© 2010-2020 University of Manchester <soiland-reyes@cs.manchester.ac.uk>  
+© 2014-2015 Stian Soiland-Reyes <stian@soiland-reyes.com>  
+© 2015 Yannick De Turck  
+© 2017-2018 University of Dundee  
+© 2017 Glencoe Software  
+© 2017 GNF  
+© 2017 connexta / OCTO  
+© 2018 Jurgen Doll / Lightware Software  
+© 2018 BFO  
+© 2020 Egor Radchenko  
 
 
 

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -10,6 +10,7 @@
 © 2018 Jurgen Doll / Lightware Software  
 © 2018 BFO  
 © 2020 Egor Radchenko  
+© 2017 Matt Parker
 
 
 

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,8 +1,13 @@
 # Build modifications
 
-(c) 2010-2015 University of Manchester <soiland-reyes@cs.manchester.ac.uk>
-(c) 2014-2015 Stian Soiland-Reyes <stian@soiland-reyes.com>
-(c) 2015 Yannick De Turck
+© 2010-2020 University of Manchester <soiland-reyes@cs.manchester.ac.uk>
+© 2014-2015 Stian Soiland-Reyes <stian@soiland-reyes.com>
+© 2015 Yannick De Turck
+© 2017-2018 University of Dundee
+© 2017 Glencoe Software
+© 2017 GNF
+© 2017 connexta / OCTO
+© 2018 Jurgen Doll / Lightware Software
 
 
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Copyright and licenses
 * Copyright © 2017 GNF
 * Copyright © 2017 connexta / OCTO
 * Copyright © 2018 Jurgen Doll / Lightware Software
+* Copyright © 2018 BFO
+* Copyright © 2020 Egor Radchenko
 
 The complete copyright notice for this project is in
 [COPYRIGHT.md](COPYRIGHT.md)

--- a/README.md
+++ b/README.md
@@ -106,9 +106,14 @@ Copyright and licenses
 
 * Copyright © 1999/2000 JJ2000 Partners
 * Copyright © 2005 Sun Microsystems
-* Copyright © 2010-2015 University of Manchester
+* Copyright © 2010-2020 University of Manchester
 * Copyright © 2014-2015 Stian Soiland-Reyes
 * Copyright © 2015 Yannick De Turck
+* Copyright © 2017-2018 University of Dundee
+* Copyright © 2017 Glencoe Software
+* Copyright © 2017 GNF
+* Copyright © 2017 connexta / OCTO
+* Copyright © 2018 Jurgen Doll / Lightware Software
 
 The complete copyright notice for this project is in
 [COPYRIGHT.md](COPYRIGHT.md)

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Copyright and licenses
 * Copyright © 2018 Jurgen Doll / Lightware Software
 * Copyright © 2018 BFO
 * Copyright © 2020 Egor Radchenko
+* Copyright © 2017 Matt Parker
+
 
 The complete copyright notice for this project is in
 [COPYRIGHT.md](COPYRIGHT.md)

--- a/src/main/java/jj2000/j2k/entropy/decoder/StdEntropyDecoder.java
+++ b/src/main/java/jj2000/j2k/entropy/decoder/StdEntropyDecoder.java
@@ -81,7 +81,12 @@ public class StdEntropyDecoder extends EntropyDecoder
     implements StdEntropyCoderOptions {
 
     /** Whether to collect timing information or not: false. Used as a compile
-     * time directive. */
+     * time directive.
+     * 
+     * WARNING: This does not currently work in OpenJDK 11, 
+     * also uncomment corresponding UNCOMMENT block inline 
+     * before recompiling!
+     */
     private final static boolean DO_TIMING = false;
 
     /** The cumulative wall time for the entropy coding engine, for each
@@ -619,11 +624,15 @@ public class StdEntropyDecoder extends EntropyDecoder
         this.mQuit = mQuit;
 
         // If we do timing create necessary structures
+        /* UNCOMMENT AT COMPILE TIME
         if (DO_TIMING) {
             time = new long[src.getNumComps()];
             // If we are timing make sure that 'finalize' gets called.
             System.runFinalizersOnExit(true);
+            // NOTE: deprecated method runFinalizersOnExit removed in JDK 11+
+            // use OpenJDK 8 to test
         }
+        */
 
         // Initialize internal variables
         state = new int[(decSpec.cblks.getMaxCBlkWidth()+2) *

--- a/src/main/java/jj2000/j2k/entropy/encoder/EBCOTRateAllocator.java
+++ b/src/main/java/jj2000/j2k/entropy/encoder/EBCOTRateAllocator.java
@@ -88,7 +88,11 @@ import com.github.jaiimageio.jpeg2000.impl.J2KImageWriteParamJava;
 public class EBCOTRateAllocator extends PostCompRateAllocator {
 
     /** Whether to collect timing information or not: false. Used as a compile
-     * time directive. */
+     * time directive.
+     * 
+     * WARNING: This does not currently work in OpenJDK 11, 
+     * also uncomment corresponding UNCOMMENT block inline.
+     */
     private final static boolean DO_TIMING = false;
 
     /** The wall time for the initialization. */
@@ -221,9 +225,13 @@ public class EBCOTRateAllocator extends PostCompRateAllocator {
         Point ncblks = null;
 
         // If we do timing create necessary structures
+        /* UNCOMMENT AT COMPILE TIME
         if (DO_TIMING) {
             // If we are timing make sure that 'finalize' gets called.
             System.runFinalizersOnExit(true);
+            // NOTE: deprecated method runFinalizersOnExit removed in JDK 11+
+            // use OpenJDK 8 to test
+
             // The System.runFinalizersOnExit() method is deprecated in Java
             // 1.2 since it can cause a deadlock in some cases. However, here
             // we use it only for profiling purposes and is disabled in
@@ -232,6 +240,7 @@ public class EBCOTRateAllocator extends PostCompRateAllocator {
             buildTime = 0L;
             writeTime = 0L;
         }
+        */
 
         // Save the layer specs
         lyrSpec = lyrs;

--- a/src/main/java/jj2000/j2k/entropy/encoder/StdEntropyCoder.java
+++ b/src/main/java/jj2000/j2k/entropy/encoder/StdEntropyCoder.java
@@ -117,7 +117,11 @@ public class StdEntropyCoder extends EntropyCoder
     implements StdEntropyCoderOptions {
 
     /** Whether to collect timing information or not: false. Used as a compile
-     * time directive. */
+     * time directive.
+     * 
+     * WARNING: This does not currently work in OpenJDK 11, 
+     * also uncomment corresponding UNCOMMENT block inline.
+     */
     private final static boolean DO_TIMING = false;
 
     /** The cumulative wall time for the entropy coding engine, for each
@@ -955,11 +959,15 @@ public class StdEntropyCoder extends EntropyCoder
         }
 
         // If we do timing create necessary structures
+         /* UNCOMMENT AT COMPILE TIME
         if (DO_TIMING) {
             time = new long[src.getNumComps()];
             // If we are timing make sure that 'finalize' gets called.
             System.runFinalizersOnExit(true);
+            // NOTE: deprecated method runFinalizersOnExit removed in JDK 11+
+            // use OpenJDK 8 to test
         }
+        */
 
         // If using multithreaded implementation get necessasry objects
         if (nt > 0) {


### PR DESCRIPTION
Disable DO_TIMING blocks for OpenJDK 11 support
    
The code would no longer compile as long deprecated `System.runFinalizersOnExit` was removed by [JDK-8198249](https://bugs.openjdk.java.net/browse/JDK-8198249) in Open JDK 11.
    
As using this timing requires code modification and was never used "live" in this patch I added a `/*  UNCOMMENT  */` comment block around the offending code - it can be  enabled if compiling on Open JDK 8.

Based on #15 by @rleigh-codelibre
