### PR TITLE
Fix build with JDK 8+

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ To build this project, use OpenJDK 8 or 11, together with Apache Maven 2.2.1 or 
 
     mvn clean install
 
+(JDK 11 is preferred due to better compatibility with Java 6 target API)
+
 To use jai-imageio-core-jpeg2000 from a Maven project, add:
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,7 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <linksource>true</linksource>
           <protected>true</protected>
           <links>
@@ -212,6 +213,15 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>java-6-api</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>6</maven.compiler.release>
+      </properties>
     </profile>
   </profiles>
 


### PR DESCRIPTION
- Disable DocLint (Java 8+) to make build pass for JDK8+.
- Specify Release flag (Java 9+) to ensure Java 6 API compatibility.